### PR TITLE
Yuval/lbm1 5419 add uncorr

### DIFF
--- a/hw/block/nvme.c
+++ b/hw/block/nvme.c
@@ -40,6 +40,7 @@
 #include "qemu/cutils.h"
 #include "trace.h"
 #include "nvme.h"
+#include "qemu/bitmap.h"
 
 #define NVME_GUEST_ERR(trace, fmt, ...) \
     do { \
@@ -1320,6 +1321,7 @@ static void nvme_realize(PCIDevice *pci_dev, Error **errp)
         id_ns->ncap  = id_ns->nuse = id_ns->nsze =
             cpu_to_le64(n->ns_size >>
                 id_ns->lbaf[NVME_ID_NS_FLBAS_INDEX(ns->id_ns.flbas)].ds);
+        ns->uncorrectable = bitmap_new(id_ns->nsze);
     }
 }
 

--- a/hw/block/nvme.h
+++ b/hw/block/nvme.h
@@ -51,6 +51,7 @@ typedef struct NvmeCQueue {
 
 typedef struct NvmeNamespace {
     NvmeIdNs        id_ns;
+    unsigned long *uncorrectable;
 } NvmeNamespace;
 
 #define TYPE_NVME "nvme"


### PR DESCRIPTION
We want to add uncorrectable feature to qemu-nvme.

1.  create bitmap to follow which block will raise NVME_UNRECOVERED_READ
2.  add NVME_CMD_WRITE_UNCOR - set range of blocks to raise "unrecovered" error
3.  add in nvme_rw - if its read check if the block is uncorrectable and raise error
                                - if it write - write reset the block to be correctable.

I am not sure this is enough to work.
@roys-lb , I need to add something to qemu/block/nvme.c?